### PR TITLE
[feat] Enhanced 404 page, referrals landing page, and legacy URL redi…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,10 @@ import icon from 'astro-icon';
 export default defineConfig({
   site: 'https://hcserviclean.com',
   trailingSlash: 'always',
+  redirects: {
+    '/home':  '/',
+    '/home/': '/',
+  },
   integrations: [
     tailwind(),
     react(),

--- a/src/components/estimate/EstimateForm.astro
+++ b/src/components/estimate/EstimateForm.astro
@@ -165,6 +165,21 @@
     </div>
   </div>
 
+  <!-- Referral field -->
+  <div class="flex flex-col gap-1.5">
+    <label for="est-referral" class="text-sm font-bold text-slate-900">
+      Who referred you? <span class="text-slate-500 text-xs font-normal">(optional)</span>
+    </label>
+    <input
+      id="est-referral"
+      name="referredBy"
+      type="text"
+      autocomplete="off"
+      placeholder="e.g. Jane Smith"
+      class="input-field"
+    />
+  </div>
+
   <!-- Cloudflare Turnstile widget -->
   <div class="cf-turnstile" data-sitekey="0x4AAAAAAC2NcgP4v9l5R87v"></div>
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import BubbleDecor from '../components/shared/BubbleDecor.astro';
 ---
 
 <BaseLayout
@@ -7,21 +8,85 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   description="The page you were looking for doesn't exist. Return to the HC ServiClean homepage."
   canonical="https://hcserviclean.com/404"
 >
-  <section class="flex min-h-screen flex-col items-center justify-center bg-white px-4 py-20 text-center" aria-label="404 error">
-    <div class="mx-auto max-w-md">
-      <p class="text-8xl font-bold text-teal" aria-hidden="true">404</p>
-      <h1 class="mt-4 text-3xl font-bold text-slate-900">Page Not Found</h1>
-      <p class="mt-3 text-slate-600">
-        Sorry, we couldn't find the page you were looking for. Let's get you back on track.
+  <section
+    class="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-slate-900 px-4 py-20 text-center"
+    aria-label="404 error"
+  >
+    <!-- Dot pattern overlay -->
+    <div
+      class="pointer-events-none absolute inset-0"
+      style="background-image: radial-gradient(rgba(82,182,188,0.10) 1.5px, transparent 1.5px); background-size: 26px 26px;"
+      aria-hidden="true"
+    ></div>
+
+    <BubbleDecor variant="dark" />
+
+    <div class="relative z-10 mx-auto max-w-lg">
+
+      <!-- Spray bottle illustration -->
+      <div class="mx-auto mb-2 flex items-center justify-center" aria-hidden="true">
+        <svg viewBox="0 0 130 160" width="130" height="160" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <!-- Bottle body -->
+          <rect x="52" y="72" width="52" height="72" rx="10" fill="#52b6bc"/>
+          <!-- Bottle neck -->
+          <rect x="60" y="50" width="18" height="26" rx="5" fill="#52b6bc"/>
+          <!-- Trigger housing (gold) -->
+          <path d="M30 30 L78 30 L78 55 L60 55 L60 50 L42 50 C35 50 30 45 30 38 Z" fill="#ffca3c"/>
+          <!-- Nozzle tube -->
+          <rect x="10" y="34" width="22" height="8" rx="4" fill="#ffca3c"/>
+          <!-- Spray mist dots -->
+          <circle cx="4"  cy="30" r="3"   fill="#52b6bc" opacity="0.75"/>
+          <circle cx="1"  cy="40" r="2.2" fill="#52b6bc" opacity="0.55"/>
+          <circle cx="8"  cy="24" r="1.8" fill="white"   opacity="0.55"/>
+          <circle cx="0"  cy="47" r="1.4" fill="#52b6bc" opacity="0.35"/>
+          <circle cx="5"  cy="19" r="1.2" fill="white"   opacity="0.35"/>
+          <!-- Label area -->
+          <rect x="58" y="85" width="38" height="44" rx="6" fill="white" opacity="0.10"/>
+          <!-- HC monogram on label -->
+          <text x="65" y="110" font-size="14" font-weight="800" fill="white" opacity="0.55" font-family="sans-serif">HC</text>
+          <!-- Sparkle star — upper right -->
+          <path d="M108 18 L110 10 L112 18 L120 20 L112 22 L110 30 L108 22 L100 20 Z" fill="#ffca3c"/>
+          <!-- Small accent dots -->
+          <circle cx="98"  cy="10" r="2.5" fill="#52b6bc" opacity="0.65"/>
+          <circle cx="122" cy="36" r="2"   fill="white"   opacity="0.45"/>
+          <circle cx="90"  cy="32" r="1.5" fill="#ffca3c" opacity="0.50"/>
+        </svg>
+      </div>
+
+      <!-- 404 number -->
+      <p class="text-[7rem] font-bold leading-none text-gold sm:text-[9rem]" aria-hidden="true">404</p>
+
+      <!-- Heading -->
+      <h1 class="mt-3 text-3xl font-bold text-white sm:text-4xl">
+        This page got swept away
+      </h1>
+
+      <!-- Subtext -->
+      <p class="mt-4 text-lg leading-relaxed text-slate-400">
+        Looks like this spot is spotless — meaning it doesn't exist.
+        Let us point you somewhere that does.
       </p>
-      <div class="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-        <a href="/" class="btn-primary">
+
+      <!-- Primary CTAs -->
+      <div class="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <a href="/" class="btn-primary w-full sm:w-auto">
           Back to Home
         </a>
-        <a href="/estimate/" class="btn-teal-outline">
+        <a href="/estimate/" class="btn-outline w-full sm:w-auto">
           Get a Free Estimate
         </a>
       </div>
+
+      <!-- Quick nav links -->
+      <nav aria-label="Helpful links" class="mt-10">
+        <p class="mb-3 text-xs font-semibold uppercase tracking-widest text-slate-500">Or browse</p>
+        <ul class="flex flex-wrap justify-center gap-x-6 gap-y-2" role="list">
+          <li><a href="/services/" class="text-sm text-slate-400 transition-colors hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal rounded">Services</a></li>
+          <li><a href="/about/"    class="text-sm text-slate-400 transition-colors hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal rounded">About</a></li>
+          <li><a href="/faq/"      class="text-sm text-slate-400 transition-colors hover:text-teal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal rounded">FAQ</a></li>
+        </ul>
+      </nav>
+
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/referrals.astro
+++ b/src/pages/referrals.astro
@@ -1,0 +1,120 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import EstimateForm from '../components/estimate/EstimateForm.astro';
+import SectionHeader from '../components/shared/SectionHeader.astro';
+import BubbleDecor from '../components/shared/BubbleDecor.astro';
+import PageHeader from '../components/shared/PageHeader.astro';
+---
+
+<BaseLayout
+  title="Referred to HC ServiClean? Get a Free Estimate | Fishers, IN"
+  description="A friend trusted HC ServiClean — now they're passing that along to you. Request your free, no-obligation house cleaning estimate in Fishers, Carmel, Noblesville & Indianapolis, IN."
+  canonical="https://hcserviclean.com/referrals/"
+>
+  <!-- Cloudflare Turnstile — only loaded on this page -->
+  <script
+    slot="head"
+    src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+    async
+    defer
+  ></script>
+
+  <PageHeader
+    title="Get a Free House Cleaning Estimate in Fishers, IN"
+    subtitle="A friend trusted us with their home — and now they're passing that trust along to you. Fill out the form and we'll reach out within one business day."
+    breadcrumb="Referrals"
+  />
+
+  <!-- Form + info side by side -->
+  <section class="bg-slate-50 py-20" aria-labelledby="referral-form-heading">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col gap-12 lg:flex-row">
+        <!-- Form -->
+        <div class="w-full lg:w-2/3">
+          <SectionHeader
+            id="referral-form-heading"
+            title="Request Your Free Estimate"
+            subtitle="Tell us about your home and we'll get back to you with a personalized quote."
+          />
+          <!-- Referral welcome note -->
+          <div class="mb-4 flex items-center gap-3 rounded-xl bg-gold/10 px-4 py-3 ring-1 ring-gold/30">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5 shrink-0 text-gold" aria-hidden="true">
+              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+            </svg>
+            <p class="text-sm font-semibold text-slate-900">Someone thought of you — let's take good care of you too.</p>
+          </div>
+          <div class="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm sm:p-8">
+            <EstimateForm />
+          </div>
+        </div>
+
+        <!-- What to expect -->
+        <aside class="w-full lg:w-1/3" aria-labelledby="expect-heading">
+          <h2 id="expect-heading" class="mb-6 text-xl font-bold text-slate-900">What to Expect</h2>
+
+          <ol class="space-y-6 text-sm" role="list">
+            {[
+              {
+                step: '1',
+                title: 'Submit the Form',
+                body: 'Fill out your contact and address details. Takes about 60 seconds.',
+              },
+              {
+                step: '2',
+                title: 'We\'ll Reach Out',
+                body: 'A member of our team will contact you within one business day to discuss your needs.',
+              },
+              {
+                step: '3',
+                title: 'Get Your Quote',
+                body: 'We\'ll provide a personalized service quote — no time limits, no surprises.',
+              },
+              {
+                step: '4',
+                title: 'Schedule Your Clean',
+                body: 'Pick a date and time that works for you. You don\'t even need to be home!',
+              },
+            ].map(({ step, title, body }) => (
+              <li class="flex gap-4">
+                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-teal text-slate-900 font-bold text-sm" aria-hidden="true">
+                  {step}
+                </div>
+                <div>
+                  <p class="font-bold text-slate-900">{title}</p>
+                  <p class="mt-0.5 text-slate-600">{body}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <!-- Contact alternatives -->
+          <div class="mt-8 rounded-xl bg-teal-50 p-5">
+            <p class="text-sm font-bold text-slate-900">Prefer to call or email?</p>
+            <div class="mt-3 space-y-2">
+              <a href="tel:+18472934525" class="flex items-center gap-2 text-sm text-slate-700 hover:text-teal-dark transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-teal shrink-0" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M2 3.5A1.5 1.5 0 013.5 2h1.148a1.5 1.5 0 011.465 1.175l.716 3.223a1.5 1.5 0 01-1.052 1.767l-.933.267c-.41.117-.643.555-.48.95a11.542 11.542 0 006.254 6.254c.395.163.833-.07.95-.48l.267-.933a1.5 1.5 0 011.767-1.052l3.223.716A1.5 1.5 0 0118 15.352V16.5a1.5 1.5 0 01-1.5 1.5H15c-1.149 0-2.263-.15-3.326-.43A13.022 13.022 0 012.43 8.326 13.019 13.019 0 012 5V3.5z" clip-rule="evenodd"/>
+                </svg>
+                (847) 293-4525
+              </a>
+              <a href="mailto:info@hcserviclean.com" class="flex items-center gap-2 text-sm text-slate-700 hover:text-teal-dark transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4 text-teal shrink-0" aria-hidden="true">
+                  <path d="M3 4a2 2 0 00-2 2v1.161l8.441 4.221a1.25 1.25 0 001.118 0L19 7.162V6a2 2 0 00-2-2H3z"/>
+                  <path d="M19 8.839l-7.77 3.885a2.75 2.75 0 01-2.46 0L1 8.839V14a2 2 0 002 2h14a2 2 0 002-2V8.839z"/>
+                </svg>
+                info@hcserviclean.com
+              </a>
+            </div>
+          </div>
+
+          <!-- Payment note -->
+          <div class="mt-4 rounded-xl border border-slate-200 p-4">
+            <p class="text-xs font-bold uppercase tracking-widest text-slate-500">Payment</p>
+            <p class="mt-1 text-sm text-slate-600">We currently accept <strong>cash and checks</strong>.</p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </section>
+
+</BaseLayout>


### PR DESCRIPTION
…rects

- 404: dark bg-slate-900 with dot pattern, BubbleDecor, inline spray bottle SVG, gold "404" number, on-brand headline "This page got swept away"
- referrals: new /referrals/ page mirroring estimate layout with referral welcome badge
- estimate: "Who referred you?" optional field added to EstimateForm (always visible)
- astro.config: /home and /home/ redirects added for legacy URL SEO coverage